### PR TITLE
Feature/issue 9 strength 5levels

### DIFF
--- a/.docs/feature-strength-5levels.md
+++ b/.docs/feature-strength-5levels.md
@@ -1,0 +1,220 @@
+# 機能対応計画：パスワード強度の評価を5段階に変更する
+
+> 作成日: 2026-03-12  
+> 対象 Issue: [#9 パスワード強度の評価を5段階に変更する](https://github.com/rocket-martue/password-generator/issues/9)  
+> 作業ブランチ: `feature/issue-9-strength-5levels`  
+> ステータス: 実装前
+
+---
+
+## 概要
+
+現在4段階で評価しているパスワード強度を、以下の5段階に変更する。
+
+| level | ラベル | 意味 |
+|---|---|---|
+| 0 | 非常に脆弱 | 極めて予測されやすいパスワード |
+| 1 | 脆弱 | 十分なエントロピーがなく危険 |
+| 2 | 普通 | 最低限の強度はあるが推奨されない |
+| 3 | 強力 | 十分なセキュリティ強度がある |
+| 4 | 非常に強力 | 高エントロピーで強固なパスワード |
+
+---
+
+## 現状の実装
+
+### `js/generator.js` — `calcStrength()`
+
+```js
+// 現行: 4段階 (level 0〜3)
+if (entropy < 40) return { label: '弱', level: 0 };
+if (entropy < 60) return { label: '普通', level: 1 };
+if (entropy < 80) return { label: '強', level: 2 };
+return { label: '非常に強い', level: 3 };
+```
+
+戻り値の型: `{ label: string, level: 0|1|2|3 }`
+
+### `js/app.js` — `STRENGTH_CLASSES`
+
+```js
+// 現行: 4クラス
+const STRENGTH_CLASSES = [
+  'strength-weak',
+  'strength-fair',
+  'strength-strong',
+  'strength-very-strong'
+];
+```
+
+### `scss/_strength.scss` — data-level ごとの表示
+
+```scss
+// 現行: 4段階 (data-level 0〜3)
+&[data-level="0"]::after { width: 25%; background: var(--danger); }
+&[data-level="1"]::after { width: 50%; background: var(--warning); }
+&[data-level="2"]::after { width: 75%; background: var(--success); }
+&[data-level="3"]::after { width: 100%; background: linear-gradient(...); }
+```
+
+---
+
+## 変更対象ファイルと実装内容
+
+### 1. `js/generator.js` — エントロピー閾値と戻り値の変更
+
+#### 新しいエントロピー区分
+
+| level | ラベル | エントロピー閾値 | 根拠 |
+|---|---|---|---|
+| 0 | 非常に脆弱 | < 28 bit | 辞書攻撃・ブルートフォースで即突破 |
+| 1 | 脆弱 | < 40 bit | 現行の「弱」基準を継承 |
+| 2 | 普通 | < 60 bit | 現行の「普通」基準を継承 |
+| 3 | 強力 | < 80 bit | 現行の「強」基準を継承 |
+| 4 | 非常に強力 | ≥ 80 bit | 現行の「非常に強い」基準を継承 |
+
+#### 変更後コード
+
+```js
+/**
+ * @returns {{ label: string, level: 0|1|2|3|4 }}
+ *   level: 0=非常に脆弱, 1=脆弱, 2=普通, 3=強力, 4=非常に強力
+ */
+export const calcStrength = (pool, length) => {
+  if (pool.length === 0 || length === 0) {
+    return { label: '—', level: 0 };
+  }
+
+  const entropy = Math.log2(pool.length) * length;
+
+  if (entropy < 28) return { label: '非常に脆弱', level: 0 };
+  if (entropy < 40) return { label: '脆弱',       level: 1 };
+  if (entropy < 60) return { label: '普通',        level: 2 };
+  if (entropy < 80) return { label: '強力',        level: 3 };
+  return              { label: '非常に強力',      level: 4 };
+};
+```
+
+---
+
+### 2. `js/app.js` — `STRENGTH_CLASSES` を5要素に拡張
+
+#### 変更後コード
+
+```js
+const STRENGTH_CLASSES = [
+  'strength-very-weak',   // level 0: 非常に脆弱
+  'strength-weak',        // level 1: 脆弱
+  'strength-fair',        // level 2: 普通
+  'strength-strong',      // level 3: 強力
+  'strength-very-strong', // level 4: 非常に強力
+];
+```
+
+`indicator.setAttribute('aria-valuemax', 4)` も合わせて更新する（現在は 3 で固定されているかHTML側で確認要）。
+
+---
+
+### 3. `scss/_strength.scss` — バー幅とカラーを5段階に拡張
+
+#### 変更後コード
+
+```scss
+// 5段階 (data-level 0〜4)
+&[data-level="0"]::after {
+  width: 20%;
+  background: var(--danger);         // 非常に脆弱: 赤
+}
+&[data-level="1"]::after {
+  width: 40%;
+  background: var(--warning);        // 脆弱: オレンジ
+}
+&[data-level="2"]::after {
+  width: 60%;
+  background: var(--caution);        // 普通: 黄
+}
+&[data-level="3"]::after {
+  width: 80%;
+  background: var(--success);        // 強力: 緑
+}
+&[data-level="4"]::after {
+  width: 100%;
+  background: linear-gradient(90deg, var(--accent-from), var(--accent-to));
+                                     // 非常に強力: グラデーション
+}
+```
+
+> **注意**: `--caution` 変数が `scss/_variables.scss` に存在するか確認が必要。  
+> 存在しない場合は `#eab308`（黄色系）を追加定義する。
+
+---
+
+### 4. `scss/_variables.scss` — `--caution` カラー変数の確認・追加（必要な場合）
+
+```scss
+// ライトテーマ
+:root {
+  --caution: #ca8a04;  /* 黄: level 2 (普通) に使用 */
+}
+
+// ダークテーマ
+[data-theme="dark"] {
+  --caution: #fbbf24;
+}
+```
+
+---
+
+### 5. `index.html` — aria 属性の確認・更新
+
+`aria-valuemax` が `3` にハードコードされていた場合、`4` に更新する。
+
+```html
+<!-- 変更前 -->
+<div id="strength-indicator" ... aria-valuemax="3">
+
+<!-- 変更後 -->
+<div id="strength-indicator" ... aria-valuemax="4">
+```
+
+---
+
+## 影響範囲の整理
+
+| ファイル | 変更の性質 | 影響度 |
+|---|---|---|
+| `js/generator.js` | `calcStrength()` の閾値・ラベル・戻り値の型変更 | 中（ロジック変更） |
+| `js/app.js` | `STRENGTH_CLASSES` の要素数変更 | 小（定数のみ） |
+| `scss/_strength.scss` | `data-level` ごとのスタイル変更 | 小（ビジュアル） |
+| `scss/_variables.scss` | `--caution` 変数の追加（必要な場合） | 小 |
+| `index.html` | `aria-valuemax` の値変更（確認後） | 極小 |
+| `css/style.css` | SCSS コンパイル後の成果物 | コンパイルで自動反映 |
+
+---
+
+## 実装チェックリスト
+
+- [ ] `js/generator.js` — `calcStrength()` を5段階に更新
+- [ ] `js/generator.js` — JSDoc コメントの型定義を `0|1|2|3|4` に更新
+- [ ] `js/app.js` — `STRENGTH_CLASSES` を5要素に更新
+- [ ] `scss/_variables.scss` — `--caution` 変数の有無を確認・追加
+- [ ] `scss/_strength.scss` — `data-level` を5段階に更新
+- [ ] `index.html` — `aria-valuemax` の値を確認・更新
+- [ ] `css/style.css` — SCSS をコンパイルして反映
+- [ ] ブラウザで動作確認（各エントロピー帯でラベル・バーが正しく表示される）
+- [ ] PR 作成して Issue #9 にリンク
+
+---
+
+## 動作確認の観点
+
+| 確認項目 | 確認方法 |
+|---|---|
+| level 0（非常に脆弱）が表示される | 長さ6・数字のみ → エントロピー ≈ 20 bit |
+| level 1（脆弱）が表示される | 長さ8・小文字のみ → エントロピー ≈ 38 bit |
+| level 2（普通）が表示される | 長さ10・英数字 → エントロピー ≈ 50 bit |
+| level 3（強力）が表示される | 長さ12・英数字＋記号 → エントロピー ≈ 72 bit |
+| level 4（非常に強力）が表示される | 長さ16・全文字種 → エントロピー ≈ 100 bit |
+| バー幅が 20/40/60/80/100% になる | 目視確認 |
+| ダークテーマでも視認性がある | テーマ切り替えで確認 |
+| 空の文字プールで '—' が表示される | 全文字種を OFF |

--- a/.docs/feature-strength-5levels.md
+++ b/.docs/feature-strength-5levels.md
@@ -67,11 +67,11 @@ const STRENGTH_CLASSES = [
 
 | level | ラベル | エントロピー閾値 | 根拠 |
 |---|---|---|---|
-| 0 | 非常に脆弱 | < 28 bit | 辞書攻撃・ブルートフォースで即突破 |
-| 1 | 脆弱 | < 40 bit | 現行の「弱」基準を継承 |
-| 2 | 普通 | < 60 bit | 現行の「普通」基準を継承 |
-| 3 | 強力 | < 80 bit | 現行の「強」基準を継承 |
-| 4 | 非常に強力 | ≥ 80 bit | 現行の「非常に強い」基準を継承 |
+| 0 | 非常に脆弱 | < 30 bit | 辞書攻撃・ブルートフォースで即突破 |
+| 1 | 脆弱 | < 55 bit | 現行の「弱」基準を継承 |
+| 2 | 普通 | < 70 bit | 現行の「普通」基準を継承 |
+| 3 | 強力 | < 90 bit | 現行の「強」基準を継承 |
+| 4 | 非常に強力 | ≥ 90 bit | 現行の「非常に強い」基準を継承 |
 
 #### 変更後コード
 
@@ -87,10 +87,10 @@ export const calcStrength = (pool, length) => {
 
   const entropy = Math.log2(pool.length) * length;
 
-  if (entropy < 28) return { label: '非常に脆弱', level: 0 };
-  if (entropy < 40) return { label: '脆弱',       level: 1 };
-  if (entropy < 60) return { label: '普通',        level: 2 };
-  if (entropy < 80) return { label: '強力',        level: 3 };
+  if (entropy < 30) return { label: '非常に脆弱', level: 0 };
+  if (entropy < 55) return { label: '脆弱',       level: 1 };
+  if (entropy < 70) return { label: '普通',        level: 2 };
+  if (entropy < 90) return { label: '強力',        level: 3 };
   return              { label: '非常に強力',      level: 4 };
 };
 ```
@@ -210,10 +210,10 @@ const STRENGTH_CLASSES = [
 
 | 確認項目 | 確認方法 |
 |---|---|
-| level 0（非常に脆弱）が表示される | 長さ6・数字のみ → エントロピー ≈ 20 bit |
-| level 1（脆弱）が表示される | 長さ8・小文字のみ → エントロピー ≈ 38 bit |
-| level 2（普通）が表示される | 長さ10・英数字 → エントロピー ≈ 50 bit |
-| level 3（強力）が表示される | 長さ12・英数字＋記号 → エントロピー ≈ 72 bit |
+| level 0（非常に脆弱）が表示される | 長さ6・数字のみ → エントロピー ≈ 30 bit |
+| level 1（脆弱）が表示される | 長さ8・小文字のみ → エントロピー ≈ 55 bit |
+| level 2（普通）が表示される | 長さ10・英数字 → エントロピー ≈ 70 bit |
+| level 3（強力）が表示される | 長さ12・英数字＋記号 → エントロピー ≈ 90 bit |
 | level 4（非常に強力）が表示される | 長さ16・全文字種 → エントロピー ≈ 100 bit |
 | バー幅が 20/40/60/80/100% になる | 目視確認 |
 | ダークテーマでも視認性がある | テーマ切り替えで確認 |

--- a/css/style.css
+++ b/css/style.css
@@ -21,6 +21,7 @@
   --text-muted: #4d6b8a;
   --success: #34c759;
   --warning: #ff9500;
+  --caution: #ca8a04;
   --danger: #ff3b30;
   --radius-sm: 8px;
   --radius-md: 12px;
@@ -71,6 +72,7 @@
   --text-muted: #5a8ab0;
   --success: #30d158;
   --warning: #ff9f0a;
+  --caution: #fbbf24;
   --danger: #ff453a;
   --select-arrow: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%2390bae0' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
 }
@@ -868,18 +870,22 @@ body {
   width: 0;
 }
 .strength-indicator[data-level="0"]::after {
-  width: 25%;
+  width: 20%;
   background: var(--danger);
 }
 .strength-indicator[data-level="1"]::after {
-  width: 50%;
+  width: 40%;
   background: var(--warning);
 }
 .strength-indicator[data-level="2"]::after {
-  width: 75%;
-  background: var(--success);
+  width: 60%;
+  background: var(--caution);
 }
 .strength-indicator[data-level="3"]::after {
+  width: 80%;
+  background: var(--success);
+}
+.strength-indicator[data-level="4"]::after {
   width: 100%;
   background: -webkit-gradient(linear, left top, right top, from(var(--accent-from)), to(var(--accent-to)));
   background: linear-gradient(90deg, var(--accent-from), var(--accent-to));

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
 						<h3 class="section-title">強度（予測）</h3>
 						<div class="strength-row">
 							<div id="strength-indicator" class="strength-indicator" role="meter" aria-label="パスワード強度"
-								aria-valuemin="0" aria-valuemax="3" aria-valuenow="3" data-level="3"></div>
+								aria-valuemin="0" aria-valuemax="4" aria-valuenow="4" data-level="4"></div>
 							<span id="strength-label" class="strength-label" aria-live="polite">—</span>
 						</div>
 

--- a/js/app.js
+++ b/js/app.js
@@ -275,7 +275,13 @@ const getCurrentOptions = () => ({
 
 // ─── 強度表示 ──────────────────────────────────────────────────────────────
 
-const STRENGTH_CLASSES = ['strength-weak', 'strength-fair', 'strength-strong', 'strength-very-strong'];
+const STRENGTH_CLASSES = [
+	'strength-very-weak',   // level 0: 非常に脆弱
+	'strength-weak',        // level 1: 脆弱
+	'strength-fair',        // level 2: 普通
+	'strength-strong',      // level 3: 強力
+	'strength-very-strong', // level 4: 非常に強力
+];
 
 const updateStrengthDisplay = () => {
 	const opts = getCurrentOptions();

--- a/js/generator.js
+++ b/js/generator.js
@@ -92,11 +92,13 @@ export const generatePasswords = (options) => {
  * パスワード強度をエントロピーで評価する
  *
  * エントロピー = log2(文字プールサイズ) × パスワード長
+ * 文字種が3種類未満の場合は level 4（非常に強力）に到達しない。
+ * 英字だけ・数字だけなどの単一・2種類構成はルールベース攻撃に弱いため制限する。
  *
  * @param {string} pool   文字プール
  * @param {number} length パスワード長
- * @returns {{ label: string, level: 0|1|2|3 }}
- *   level: 0=弱, 1=普通, 2=強, 3=非常に強い
+ * @returns {{ label: string, level: 0|1|2|3|4 }}
+ *   level: 0=非常に脆弱, 1=脆弱, 2=普通, 3=強力, 4=非常に強力
  */
 export const calcStrength = (pool, length) => {
 	if (pool.length === 0 || length === 0) {
@@ -105,8 +107,25 @@ export const calcStrength = (pool, length) => {
 
 	const entropy = Math.log2(pool.length) * length;
 
-	if (entropy < 40) return { label: '弱', level: 0 };
-	if (entropy < 60) return { label: '普通', level: 1 };
-	if (entropy < 80) return { label: '強', level: 2 };
-	return { label: '非常に強い', level: 3 };
+	// 使用している文字カテゴリ数を pool の内容から判定する
+	const categoryCount = [
+		/[A-Z]/.test(pool),
+		/[a-z]/.test(pool),
+		/[0-9]/.test(pool),
+		/[^A-Za-z0-9]/.test(pool),
+	].filter(Boolean).length;
+
+	// 文字種が3種類未満なら「非常に強力」には到達させない
+	const maxLevel = categoryCount >= 3 ? 4 : 3;
+
+	let rawLevel;
+	if (entropy < 30) rawLevel = 0;
+	else if (entropy < 55) rawLevel = 1;
+	else if (entropy < 70) rawLevel = 2;
+	else if (entropy < 96) rawLevel = 3;
+	else rawLevel = 4;
+
+	const level = Math.min(rawLevel, maxLevel);
+	const LABELS = ['非常に脆弱', '脆弱', '普通', '強力', '非常に強力'];
+	return { label: LABELS[level], level };
 };

--- a/scss/_strength.scss
+++ b/scss/_strength.scss
@@ -27,23 +27,28 @@
 	}
 
 	&[data-level="0"]::after {
-		width: 25%;
-		background: var(--danger);
+		width: 20%;
+		background: var(--danger); // 非常に脆弱: 赤
 	}
 
 	&[data-level="1"]::after {
-		width: 50%;
-		background: var(--warning);
+		width: 40%;
+		background: var(--warning); // 脆弱: オレンジ
 	}
 
 	&[data-level="2"]::after {
-		width: 75%;
-		background: var(--success);
+		width: 60%;
+		background: var(--caution); // 普通: 黄
 	}
 
 	&[data-level="3"]::after {
+		width: 80%;
+		background: var(--success); // 強力: 緑
+	}
+
+	&[data-level="4"]::after {
 		width: 100%;
-		background: linear-gradient(90deg, var(--accent-from), var(--accent-to));
+		background: linear-gradient(90deg, var(--accent-from), var(--accent-to)); // 非常に強力: グラデーション
 	}
 }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -32,6 +32,7 @@
 	// ── ステータス ─────────────────────────────────────────────
 	--success: #34c759;
 	--warning: #ff9500;
+	--caution: #ca8a04; // 黄: level 2（普通）に使用
 	--danger: #ff3b30;
 
 	// ── 共通 ───────────────────────────────────────────────────
@@ -98,6 +99,7 @@
 
 	--success: #30d158;
 	--warning: #ff9f0a;
+	--caution: #fbbf24; // 黄: level 2（普通）に使用
 	--danger: #ff453a;
 
 	--select-arrow: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%2390bae0' d='M6 8L1 3h10z'/%3E%3C/svg%3E");


### PR DESCRIPTION
feat: パスワード強度評価を5段階に変更 (https://github.com/rocket-martue/password-generator/issues/9)
- calcStrength() のエントロピー閾値を5段階に更新（< 30/55/70/96 bit）
- 文字種が3種類未満の場合は level 4（非常に強力）に到達しないよう制限
- STRENGTH_CLASSES に strength-very-weak を追加（5要素化）
- --caution カラー変数をライト/ダークテーマに追加（level 2 用）
- _strength.scss の data-level を5段階（20/40/60/80/100%）に更新
- aria-valuemax を 3 → 4 に更新